### PR TITLE
Fix: missing else clause in next_id

### DIFF
--- a/lib/sonyflake.ex
+++ b/lib/sonyflake.ex
@@ -99,7 +99,8 @@ defmodule Sonyflake do
                 overtime = new_elapsed_time - current_time
                 Process.sleep(overtime)
                 %Sonyflake{sonyflake | sequence: sequence, elapsed_time: new_elapsed_time}
-              )
+              ),
+            else: sonyflake
 
         temp
       end


### PR DESCRIPTION
Hello! I hope this project is still alive and it is ok for me to send you a PR to fix this issue.

Missing `else` in if call starting at line 95 in lib/sonyflake.ex causes `temp` to be set to nil when sequence is different from zero. This error is triggered for very fast calls to get the next ID.

To reproduce the error just run the following code

```elixir
defmodule IdGenerator do
  def run() do
    sf = Sonyflake.new()
    generate(sf)
  end

  def generate(sf) do
    receive do
        :next ->
            {:ok, new_sf, id} = Sonyflake.next_id(sf)
            IO.puts "ID=#{id}"
            generate(new_sf)
    end
  end
end

pid = spawn_link(IdGenerator, :run, [])

for _ <- 0..10 do
    send(pid, :next)
end
```

It causes the following error:
```
** (FunctionClauseError) no function clause matching in Sonyflake.to_id/1
    (sonyflake_ex 1.0.0) lib/sonyflake.ex:110: Sonyflake.to_id(nil)
    (sonyflake_ex 1.0.0) lib/sonyflake.ex:107: Sonyflake.next_id/1
    iex:39: IdGenerator.generate/1  
```
